### PR TITLE
Feature/ignore py repl

### DIFF
--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -108,6 +108,7 @@ function isScriptLikeTag(node) {
     node.type === "element" &&
     (node.fullName === "py-script" ||
       node.fullName === "py-config" ||
+      node.fullName === "py-repl" ||
       node.fullName === "script" ||
       node.fullName === "style" ||
       node.fullName === "svg:style" ||


### PR DESCRIPTION
## Description

Just as we discussed in the other PR. I did not add the CLI options. I guess that this needs quite a lot of changes, since we need pass `options` to every function that calls `isScriptLikeTag` and write the corresponding tests. Also would need to add the parsing, which seems rather easy. 